### PR TITLE
fix(docs): correct Braintree reporting endpoint payload

### DIFF
--- a/demos/app/api/braintree/confirm/route.ts
+++ b/demos/app/api/braintree/confirm/route.ts
@@ -5,11 +5,13 @@ import braintree from "braintree";
 type BTTransaction = {
   id: string;
   status: string;
-  amount: string;
+  amount_subtotal: string;
+  amount_total: string;
   processorResponseText: string;
 };
 type BraintreeReport = {
   accelerateToken: string;
+  userEmail?: string;
   transaction: BTTransaction;
 };
 
@@ -40,7 +42,8 @@ export async function POST(request: NextRequest) {
     transaction: {
       id: result.transaction.id,
       status: result.transaction.status,
-      amount: result.transaction.amount,
+      amount_subtotal: result.transaction.amount,
+      amount_total: result.transaction.amount,
       processorResponseText: result.transaction.processorResponseText,
     },
   };

--- a/docs/integrations/braintree.md
+++ b/docs/integrations/braintree.md
@@ -75,10 +75,14 @@ Details of the payload body:
 // This is the nonce value used to execute the transaction and is used by Accelerate to associate the result with the original request
   "accelerateToken": "string",
 
+// Optional email address associated with the user who completed the transaction
+  "userEmail": "string",
+
 // The fields in the transaction block should be copied from the result of the transaction.sale call
   "transaction": {
     "id": "string",
-    "amount": "string",
+    "amount_subtotal": "string",
+    "amount_total": "string",
     "status": "string",
     "processorResponseText": "string"
   }


### PR DESCRIPTION
## Summary

- The Braintree reporting endpoint docs and example code documented a single `amount` field in the transaction payload, but the actual API (`POST /reporting/braintree`) expects `amount_subtotal` and `amount_total` as separate fields
- Added the optional `userEmail` field to the docs and TypeScript types, which was missing but supported by the API
- Updated the example code in `demos/app/api/braintree/confirm/route.ts` to use the correct field names

## Test plan

- [ ] Verify the payload documented in `docs/integrations/braintree.md` matches the `BraintreeReport` / `BTTransaction` records in `Accelerate.Api/Controllers/Reporting/ReportingController.cs`
- [ ] Verify the TypeScript types in `demos/app/api/braintree/confirm/route.ts` match the API schema
- [ ] Check the OpenAPI spec at `https://sbx.api.weaccelerate.com/swagger/reporting/swagger.json` reflects the same fields
- [ ] Confirm example code compiles with `npm run build`

Munr-Job-ID: acc1a1b8a91e4142b2abb20e2168944a
Munr-Session-ID: f26a4f7c-6e50-4a8a-8b12-c3d5e7f9a1b2